### PR TITLE
Fix URL in pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Python 2.7 and 3.4+
 If the python package is hosted on Github, you can install directly from Github
 
 ```sh
-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
+pip install git+https://github.com/ClickSend/clicksend-python.git
 ```
-(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
+(you may need to run `pip` with root permission: `sudo pip install git+git+https://github.com/ClickSend/clicksend-python.git`)
 
 Then import the package:
 ```python


### PR DESCRIPTION
This fixes the URL listed in the pip install instructions from a generic github URL to the one for this repository.